### PR TITLE
Implement/derive common traits

### DIFF
--- a/wpilib-sys/src/bindings.rs
+++ b/wpilib-sys/src/bindings.rs
@@ -13,4 +13,21 @@
 #![allow(clippy::cast_lossless)]
 #![allow(clippy::trivially_copy_pass_by_ref)]
 
+use std::ffi;
+use std::fmt;
+
 include!(concat!(env!("OUT_DIR"), "/hal_bindings.rs"));
+
+impl fmt::Debug for HAL_JoystickDescriptor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name: Vec<_> = self.name.iter().map(|item| *item as u8).collect();
+        let name = &ffi::CString::new(name);
+        f.debug_struct("HAL_JoystickDescriptor")
+            .field("name", name)
+            .field("isXbox", &self.isXbox)
+            .field("axisCount", &self.axisCount)
+            .field("buttonCount", &self.buttonCount)
+            .field("povCount", &self.povCount)
+            .finish()
+    }
+}

--- a/wpilib-sys/src/hal_call.rs
+++ b/wpilib-sys/src/hal_call.rs
@@ -100,10 +100,7 @@ impl<T> HalMaybe<T> {
 
     /// Returns true if there is an error
     pub fn has_err(&self) -> bool {
-        match self.err {
-            Some(_) => true,
-            None => false,
-        }
+        self.err.is_some()
     }
 
     /// Access the potential error.

--- a/wpilib-sys/src/hal_call.rs
+++ b/wpilib-sys/src/hal_call.rs
@@ -81,6 +81,7 @@ pub type HalResult<T> = Result<T, HalError>;
 /// the way the WPILib HAL handles things, this comes up a lot.
 /// Like `Result`, `HalMaybe` must be used.
 #[must_use]
+#[derive(Copy, Clone, Debug)]
 pub struct HalMaybe<T> {
     ret: T,
     err: Option<HalError>,

--- a/wpilib/src/analog_input.rs
+++ b/wpilib/src/analog_input.rs
@@ -33,6 +33,7 @@ use std::{thread, time};
 use wpilib_sys::*;
 
 /// An analog input on the RoboRIO
+#[derive(Debug)]
 pub struct AnalogInput {
     channel: i32,
     port: HAL_AnalogInputHandle,

--- a/wpilib/src/dio.rs
+++ b/wpilib/src/dio.rs
@@ -35,6 +35,7 @@ use wpilib_sys::*;
 
 /// A digital output used to control lights, etc from the RoboRIO.
 #[allow(dead_code)]
+#[derive(Debug)]
 pub struct DigitalOutput {
     channel: i32,
     handle: HAL_DigitalHandle,
@@ -154,6 +155,7 @@ impl Drop for DigitalOutput {
  * implemented anywhere else.
  */
 #[allow(dead_code)]
+#[derive(Debug)]
 pub struct DigitalInput {
     channel: i32,
     handle: HAL_DigitalHandle,

--- a/wpilib/src/ds.rs
+++ b/wpilib/src/ds.rs
@@ -45,13 +45,13 @@ const JOYSTICK_PORTS: usize = 6;
 const JOYSTICK_AXES: usize = 12;
 const JOYSTICK_POVS: usize = 12;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Alliance {
     Red,
     Blue,
 }
 
-// #[derive(Debug, Copy, Clone)]
+// #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 // enum MatchType {
 //     None,
 //     Practice,
@@ -59,7 +59,7 @@ pub enum Alliance {
 //     Elimination,
 // }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum RobotState {
     Disabled,
     Autonomous,
@@ -69,6 +69,7 @@ pub enum RobotState {
 }
 
 // TODO: implement matchinfo data
+// #[derive(Debug)]
 // struct MatchInfoData {
 //     event_name: String,
 //     game_specific_message: String,
@@ -77,7 +78,7 @@ pub enum RobotState {
 //     match_type: MatchType,
 // }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct Joysticks {
     axes: [HAL_JoystickAxes; JOYSTICK_PORTS],
     povs: [HAL_JoystickPOVs; JOYSTICK_PORTS],
@@ -85,7 +86,7 @@ struct Joysticks {
     descriptor: [HAL_JoystickDescriptor; JOYSTICK_PORTS],
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum JoystickError {
     JoystickDNE,
     ChannelUnplugged,
@@ -93,6 +94,7 @@ pub enum JoystickError {
     DsUnreachable,
 }
 
+#[derive(Debug)]
 pub struct DriverStation {
     joysticks: Joysticks,
     control_word: HAL_ControlWord,

--- a/wpilib/src/joystick.rs
+++ b/wpilib/src/joystick.rs
@@ -37,7 +37,7 @@ use wpilib_sys::*;
 const RUMBLE_BASE: i32 = 65535;
 
 /// Enum for accessing elements of XBox controller by side
-#[derive(PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum JoystickSide {
     /// left side of joystick while held upright
     LeftHand,
@@ -62,6 +62,7 @@ pub trait JoystickBase {
 }
 
 /// stuct for almost any FRC legal joystick
+#[derive(Debug)]
 pub struct Joystick {
     port: usize,
     ds: ThreadSafeDs,

--- a/wpilib/src/pdp.rs
+++ b/wpilib/src/pdp.rs
@@ -35,6 +35,7 @@ use std::f64::NAN;
 use wpilib_sys::*;
 
 /// An interface to the PDP for getting information about robot power.
+#[derive(Debug)]
 pub struct PowerDistributionPanel {
     handle: HAL_PDPHandle,
 }

--- a/wpilib/src/pneumatics.rs
+++ b/wpilib/src/pneumatics.rs
@@ -13,6 +13,7 @@ use wpilib_sys::*;
 /// Getting info about a solenoid module, (conceptually a PCM).
 /// Even though each Solenoid will have a different instance, they all will
 /// probably refer to the same piece of hardware.
+#[derive(Debug)]
 pub struct SolenoidModule {
     module: i32,
 }
@@ -64,6 +65,7 @@ impl SolenoidModule {
     }
 }
 
+#[derive(Debug)]
 pub struct Solenoid {
     solenoid_handle: HAL_SolenoidHandle,
     channel: i32,
@@ -146,13 +148,14 @@ impl Drop for Solenoid {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Action {
     Forward,
     Reverse,
     Off,
 }
 
+#[derive(Debug)]
 pub struct DoubleSolenoid {
     forward: Solenoid,
     reverse: Solenoid,
@@ -224,6 +227,7 @@ impl DoubleSolenoid {
     }
 }
 
+#[derive(Debug)]
 pub struct Compressor {
     compressor_handle: HAL_CompressorHandle,
     module: i32,

--- a/wpilib/src/pwm.rs
+++ b/wpilib/src/pwm.rs
@@ -9,6 +9,7 @@ use sensor_util;
 use wpilib_sys::*;
 
 /// Represents the amount to multiply the minimum servo-pulse pwm period by.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum PeriodMultiplier {
     /// Don't skip pulses. PWM pulses occur every 5.005 ms
     Multiplier1x = 0,
@@ -18,6 +19,7 @@ pub enum PeriodMultiplier {
     Multiplier4x = 3,
 }
 
+#[derive(Debug)]
 pub struct PWM {
     channel: i32,
     handle: HAL_DigitalHandle,
@@ -169,6 +171,7 @@ impl Drop for PWM {
     }
 }
 
+#[derive(Debug)]
 pub struct PwmSpeedController {
     pwm: PWM,
     inverted: bool,

--- a/wpilib/src/robot_base.rs
+++ b/wpilib/src/robot_base.rs
@@ -35,6 +35,7 @@ use std::sync::*;
 use std::time::Duration;
 use wpilib_sys::*;
 
+#[derive(Debug)]
 pub struct RobotBase {
     ds: ThreadSafeDs,
 }

--- a/wpilib/src/serial.rs
+++ b/wpilib/src/serial.rs
@@ -22,7 +22,7 @@ type byte = i8;
 
 // all of these enums use magic numbers from wpilibc SerialPort.h
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Port {
     Onboard = 0,
     MXP = 1,
@@ -30,7 +30,7 @@ pub enum Port {
     USB2 = 3,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Parity {
     None = 0,
     Odd = 1,
@@ -39,19 +39,20 @@ pub enum Parity {
     Space = 4,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StopBits {
     One = 10,
     OnePointFive = 15,
     Two = 20,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum WriteBufferMode {
     FlushOnAcces = 1,
     FlushWhenFull = 2,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum FlowControl {
     None = 0,
     XonXoff = 1,

--- a/wpilib/src/spi.rs
+++ b/wpilib/src/spi.rs
@@ -7,7 +7,7 @@
 
 use wpilib_sys::*;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Port {
     OnboardCS0 = 0,
     OnboardCS1 = 1,
@@ -17,6 +17,7 @@ pub enum Port {
 }
 
 /// Spi for driver writers. Currenltly does not include an accumulator.
+#[derive(Debug)]
 pub struct Spi {
     port: HAL_SPIPort,
     msb_first: bool,

--- a/wpilib/src/time.rs
+++ b/wpilib/src/time.rs
@@ -31,6 +31,7 @@ except according to those terms.
 */
 
 /// Handles only doing some task once per set interval.
+#[derive(Debug)]
 pub struct Throttler<T, S> {
     next_send: T,
     interval: S,


### PR DESCRIPTION
From the [Rust API guidelines](https://rust-lang-nursery.github.io/api-guidelines/about.html) (see #8), this resolves C-COMMON-TRAITS, C-DEBUG, and C-DEBUG-NONEMPTY. The criterion used to decide whether or not to implement a trait was whether the implementation makes logical sense, not whether it was likely to be useful. I advise that, in the future, all additions to this library should implement these traits as well.
