### PR TITLE
Remove "get_" prefix from getters

### DIFF
--- a/wpilib-examples/digital_out.rs
+++ b/wpilib-examples/digital_out.rs
@@ -14,10 +14,10 @@ fn main() {
     RobotBase::start_competition();
 
     let mut val;
-    let ds = robot.get_ds_instance();
+    let ds = robot.ds_instance();
     loop {
         {
-            val = match ds.read().unwrap().get_state() {
+            val = match ds.read().unwrap().state() {
                 ds::RobotState::Disabled => true,
                 _ => false,
             }

--- a/wpilib-examples/pdp.rs
+++ b/wpilib-examples/pdp.rs
@@ -31,11 +31,11 @@ fn print_pdp_info(pdp: &PowerDistributionPanel) {
         Current on 1: {} Amps
         Total Power: {} Watts
         Total Energy: {} Joules",
-        pdp.get_voltage().ok(),
-        pdp.get_temperature().ok(),
-        pdp.get_total_current().ok(),
-        pdp.get_current(1).ok(),
-        pdp.get_total_power().ok(),
-        pdp.get_total_energy().ok()
+        pdp.voltage().ok(),
+        pdp.temperature().ok(),
+        pdp.total_current().ok(),
+        pdp.current(1).ok(),
+        pdp.total_power().ok(),
+        pdp.total_energy().ok()
     );
 }

--- a/wpilib-examples/pneumatics.rs
+++ b/wpilib-examples/pneumatics.rs
@@ -15,10 +15,10 @@ fn main() {
     RobotBase::start_competition();
 
     let mut val;
-    let ds = robot.get_ds_instance();
+    let ds = robot.ds_instance();
     loop {
         {
-            val = match ds.read().unwrap().get_state() {
+            val = match ds.read().unwrap().state() {
                 ds::RobotState::Disabled => pneumatics::Action::Forward,
                 _ => pneumatics::Action::Reverse,
             }

--- a/wpilib/src/analog_input.rs
+++ b/wpilib/src/analog_input.rs
@@ -63,27 +63,27 @@ impl AnalogInput {
     }
 
     /// Read a value from the analog input.
-    pub fn get_value(&self) -> HalResult<i32> {
+    pub fn value(&self) -> HalResult<i32> {
         hal_call!(HAL_GetAnalogValue(self.port))
     }
 
     /// Read the average value of the analog input over some defined time period.
-    pub fn get_average_value(&self) -> HalResult<i32> {
+    pub fn average_value(&self) -> HalResult<i32> {
         hal_call!(HAL_GetAnalogAverageValue(self.port))
     }
 
     /// Read the raw value of the analog input in volts.
-    pub fn get_voltage(&self) -> HalResult<f64> {
+    pub fn voltage(&self) -> HalResult<f64> {
         hal_call!(HAL_GetAnalogVoltage(self.port))
     }
 
     /// Read the average raw value of the analog input in volts over some defined time period.
-    pub fn get_average_voltage(&self) -> HalResult<f64> {
+    pub fn average_voltage(&self) -> HalResult<f64> {
         hal_call!(HAL_GetAnalogAverageVoltage(self.port))
     }
 
     /// Get the channel number for this analog input.
-    pub fn get_channel(&self) -> i32 {
+    pub fn channel(&self) -> i32 {
         self.channel
     }
 
@@ -93,7 +93,7 @@ impl AnalogInput {
     }
 
     /// Get the previously-set number of average bits.
-    pub fn get_average_bits(&self) -> HalResult<i32> {
+    pub fn average_bits(&self) -> HalResult<i32> {
         hal_call!(HAL_GetAnalogAverageBits(self.port))
     }
 
@@ -104,19 +104,19 @@ impl AnalogInput {
     }
 
     /// Get the previously-set number of oversample bits.
-    pub fn get_oversample_bits(&self) -> HalResult<i32> {
+    pub fn oversample_bits(&self) -> HalResult<i32> {
         hal_call!(HAL_GetAnalogOversampleBits(self.port))
     }
 
     /// Get the factory scaling LSB weight constant:
     /// voltage = ((lsb_weight * 1e-9) * raw) - (offset * 1e-9)
-    pub fn get_lsb_weight(&self) -> HalResult<i32> {
+    pub fn lsb_weight(&self) -> HalResult<i32> {
         hal_call!(HAL_GetAnalogLSBWeight(self.port))
     }
 
     /// Get the factory scaling offset constant:
     /// voltage = ((lsb_weight * 1e-9) * raw) - (offset * 1e-9)
-    pub fn get_offset(&self) -> HalResult<i32> {
+    pub fn offset(&self) -> HalResult<i32> {
         hal_call!(HAL_GetAnalogOffset(self.port))
     }
 
@@ -140,9 +140,9 @@ impl AnalogInput {
     pub fn reset_accumulator(&mut self) -> HalResult<()> {
         hal_call!(HAL_ResetAccumulator(self.port))?;
 
-        let sample_time = 1f64 / AnalogInput::get_sample_rate()?;
-        let over_samples = 1 << self.get_oversample_bits()?;
-        let average_samples = 1 << self.get_average_bits()?;
+        let sample_time = 1f64 / AnalogInput::sample_rate()?;
+        let over_samples = 1 << self.oversample_bits()?;
+        let average_samples = 1 << self.average_bits()?;
         thread::sleep(time::Duration::from_micros(
             1000 * 1000 * over_samples * average_samples * sample_time as u64,
         ));
@@ -162,18 +162,18 @@ impl AnalogInput {
     }
 
     /// Get a value from the accumulator.
-    pub fn get_accumulator_value(&self) -> HalResult<i64> {
+    pub fn accumulator_value(&self) -> HalResult<i64> {
         hal_call!(HAL_GetAccumulatorValue(self.port))
     }
 
     /// Get the number of accumulated values.
-    pub fn get_accumulator_count(&self) -> HalResult<i64> {
+    pub fn accumulator_count(&self) -> HalResult<i64> {
         hal_call!(HAL_GetAccumulatorCount(self.port))
     }
 
     /// Read the accumulator's value and the count of samples at the same time.
     /// Returns a tuple of `(value, count)`.
-    pub fn get_accumulator_output(&self) -> HalResult<(i64, i64)> {
+    pub fn accumulator_output(&self) -> HalResult<(i64, i64)> {
         let value: i64 = 0;
         let count: i64 = 0;
         hal_call!(HAL_GetAccumulatorOutput(
@@ -190,7 +190,7 @@ impl AnalogInput {
     }
 
     /// Get the sample rate for analog inputs.
-    pub fn get_sample_rate() -> HalResult<f64> {
+    pub fn sample_rate() -> HalResult<f64> {
         hal_call!(HAL_GetAnalogSampleRate())
     }
 }

--- a/wpilib/src/dio.rs
+++ b/wpilib/src/dio.rs
@@ -84,12 +84,12 @@ impl DigitalOutput {
     }
 
     /// Get the channel for this DIO.
-    pub fn get_channel(&self) -> i32 {
+    pub fn channel(&self) -> i32 {
         self.channel
     }
 
     /// Get a handle to this DIO.
-    pub fn get_handle(&self) -> HAL_DigitalHandle {
+    pub fn handle(&self) -> HAL_DigitalHandle {
         self.handle
     }
 
@@ -185,7 +185,7 @@ impl DigitalInput {
         Ok(hal_call!(HAL_GetDIO(self.handle))? != 0)
     }
 
-    pub fn get_channel(&self) -> i32 {
+    pub fn channel(&self) -> i32 {
         self.channel
     }
 }

--- a/wpilib/src/ds.rs
+++ b/wpilib/src/ds.rs
@@ -229,7 +229,7 @@ impl DriverStation {
     }
 
     /// Get an axis on a joystick, in the range of [-1, 1].
-    pub fn get_joystick_axis(&self, stick: usize, axis: usize) -> Result<f32, JoystickError> {
+    pub fn joystick_axis(&self, stick: usize, axis: usize) -> Result<f32, JoystickError> {
         if stick >= JOYSTICK_PORTS {
             // self.report_throttled(true, "Bad joystick");
             Err(JoystickError::JoystickDNE)
@@ -248,7 +248,7 @@ impl DriverStation {
     }
 
     /// Get the position of a POV switch, in degrees.
-    pub fn get_joystick_pov(&self, stick: usize, pov: usize) -> Result<i16, JoystickError> {
+    pub fn joystick_pov(&self, stick: usize, pov: usize) -> Result<i16, JoystickError> {
         if stick >= JOYSTICK_POVS {
             // self.report_throttled(true, "Bad joystick");
             Err(JoystickError::JoystickDNE)
@@ -267,7 +267,7 @@ impl DriverStation {
     }
 
     /// Get the state of a button on a joystick.
-    pub fn get_joystick_button(&self, stick: usize, button: usize) -> Result<bool, JoystickError> {
+    pub fn joystick_button(&self, stick: usize, button: usize) -> Result<bool, JoystickError> {
         if stick >= JOYSTICK_POVS {
             // self.report_throttled(true, "Bad joystick");
             Err(JoystickError::JoystickDNE)
@@ -289,7 +289,7 @@ impl DriverStation {
 
     /// Get the alliance the robot is on.
     #[allow(non_upper_case_globals)]
-    pub fn get_alliance(&self) -> HalResult<Alliance> {
+    pub fn alliance(&self) -> HalResult<Alliance> {
         match hal_call!(HAL_GetAllianceStation())? {
             HAL_AllianceStationID_HAL_AllianceStationID_kRed1
             | HAL_AllianceStationID_HAL_AllianceStationID_kRed2
@@ -303,7 +303,7 @@ impl DriverStation {
 
     /// Get the id for the station the driver station is at, as an integer.
     #[allow(non_upper_case_globals)]
-    pub fn get_station(&self) -> HalResult<u32> {
+    pub fn station(&self) -> HalResult<u32> {
         match hal_call!(HAL_GetAllianceStation())? {
             HAL_AllianceStationID_HAL_AllianceStationID_kRed1
             | HAL_AllianceStationID_HAL_AllianceStationID_kBlue1 => Ok(1),
@@ -352,7 +352,7 @@ impl DriverStation {
     }
 
     /// Get the state of the robot.
-    pub fn get_state(&self) -> RobotState {
+    pub fn state(&self) -> RobotState {
         self.state
     }
 }

--- a/wpilib/src/joystick.rs
+++ b/wpilib/src/joystick.rs
@@ -48,11 +48,11 @@ pub enum JoystickSide {
 /// public trait that lays down base methods for joysticks
 pub trait JoystickBase {
     /// get raw axis value from driverstation
-    fn get_raw_axis(&self, axis: usize) -> Result<f32, JoystickError>;
+    fn raw_axis(&self, axis: usize) -> Result<f32, JoystickError>;
     /// get raw button value from driverstation
-    fn get_raw_button(&self, button: usize) -> Result<bool, JoystickError>;
+    fn raw_button(&self, button: usize) -> Result<bool, JoystickError>;
     /// get raw pov value from driverstation
-    fn get_pov(&self, pov: usize) -> Result<i16, JoystickError>;
+    fn pov(&self, pov: usize) -> Result<i16, JoystickError>;
     /// set joystick output through hal
     fn set_output(&mut self, output_number: i32, value: bool);
     /// set joystick outputs through hal
@@ -73,7 +73,7 @@ pub struct Joystick {
 impl Joystick {
     /// user creates a Joystick object here
     pub fn new(rbase: &RobotBase, port: usize) -> Joystick {
-        Self::new_raw_ds(rbase.get_ds_instance(), port)
+        Self::new_raw_ds(rbase.ds_instance(), port)
     }
 
     pub fn new_raw_ds(ds: ThreadSafeDs, port: usize) -> Joystick {
@@ -88,19 +88,19 @@ impl Joystick {
 }
 
 impl JoystickBase for Joystick {
-    fn get_raw_axis(&self, axis: usize) -> Result<f32, JoystickError> {
+    fn raw_axis(&self, axis: usize) -> Result<f32, JoystickError> {
         let read_lock = self.ds.read().map_err(|_| JoystickError::DsUnreachable)?;
-        read_lock.get_joystick_axis(self.port, axis)
+        read_lock.joystick_axis(self.port, axis)
     }
 
-    fn get_raw_button(&self, button: usize) -> Result<bool, JoystickError> {
+    fn raw_button(&self, button: usize) -> Result<bool, JoystickError> {
         let read_lock = self.ds.read().map_err(|_| JoystickError::DsUnreachable)?;
-        read_lock.get_joystick_button(self.port, button)
+        read_lock.joystick_button(self.port, button)
     }
 
-    fn get_pov(&self, pov: usize) -> Result<i16, JoystickError> {
+    fn pov(&self, pov: usize) -> Result<i16, JoystickError> {
         let read_lock = self.ds.read().map_err(|_| JoystickError::DsUnreachable)?;
-        read_lock.get_joystick_pov(self.port, pov)
+        read_lock.joystick_pov(self.port, pov)
     }
 
     fn set_output(&mut self, output_number: i32, value: bool) {

--- a/wpilib/src/pdp.rs
+++ b/wpilib/src/pdp.rs
@@ -54,7 +54,7 @@ impl PowerDistributionPanel {
     }
 
     /// Get the voltage going into the PDP.
-    pub fn get_voltage(&self) -> HalMaybe<f64> {
+    pub fn voltage(&self) -> HalMaybe<f64> {
         maybe_hal_call!(HAL_GetPDPVoltage(self.handle))
     }
 
@@ -63,7 +63,7 @@ impl PowerDistributionPanel {
     /// The `HalMaybe` returned will have an error most commonly
     /// in the case of a CAN timeout. (In Fact, this is the only
     /// error WPILib will ever report!).
-    pub fn get_temperature(&self) -> HalMaybe<f64> {
+    pub fn temperature(&self) -> HalMaybe<f64> {
         maybe_hal_call!(HAL_GetPDPTemperature(self.handle))
     }
 
@@ -76,7 +76,7 @@ impl PowerDistributionPanel {
     /// The `HalMaybe` returned will have an error most commonly
     /// in the case of a CAN timeout. (In Fact, this is the only
     /// error WPILib will ever report!).
-    pub fn get_current(&self, channel: i32) -> HalMaybe<f64> {
+    pub fn current(&self, channel: i32) -> HalMaybe<f64> {
         if !sensor_util::check_pdp_channel(channel) {
             return HalMaybe::new(NAN, Some(HalError(0)));
         }
@@ -89,7 +89,7 @@ impl PowerDistributionPanel {
     /// The `HalMaybe` returned will have an error most commonly
     /// in the case of a CAN timeout. (In Fact, this is the only
     /// error WPILib will ever report!).
-    pub fn get_total_current(&self) -> HalMaybe<f64> {
+    pub fn total_current(&self) -> HalMaybe<f64> {
         maybe_hal_call!(HAL_GetPDPTotalCurrent(self.handle))
     }
 
@@ -98,7 +98,7 @@ impl PowerDistributionPanel {
     /// The `HalMaybe` returned will have an error most commonly
     /// in the case of a CAN timeout. (In Fact, this is the only
     /// error WPILib will ever report!).
-    pub fn get_total_power(&self) -> HalMaybe<f64> {
+    pub fn total_power(&self) -> HalMaybe<f64> {
         maybe_hal_call!(HAL_GetPDPTotalPower(self.handle))
     }
 
@@ -107,7 +107,7 @@ impl PowerDistributionPanel {
     /// The `HalMaybe` returned will have an error most commonly
     /// in the case of a CAN timeout. (In Fact, this is the only
     /// error WPILib will ever report!).
-    pub fn get_total_energy(&self) -> HalMaybe<f64> {
+    pub fn total_energy(&self) -> HalMaybe<f64> {
         maybe_hal_call!(HAL_GetPDPTotalEnergy(self.handle))
     }
 

--- a/wpilib/src/pneumatics.rs
+++ b/wpilib/src/pneumatics.rs
@@ -21,38 +21,38 @@ pub struct SolenoidModule {
 impl SolenoidModule {
     /// Gets the state of each solenoid on the module with the given number.
     /// Returns a bit mask.
-    pub fn get_all_with_module(module: i32) -> HalResult<i32> {
+    pub fn all_with_module(module: i32) -> HalResult<i32> {
         hal_call!(HAL_GetAllSolenoids(module))
     }
 
-    /// Is the same as `get_all_with_module`, but on the module this instance
+    /// Is the same as `all_with_module`, but on the module this instance
     /// refers to.
-    pub fn get_all(&self) -> HalResult<i32> {
-        Self::get_all_with_module(self.module)
+    pub fn all(&self) -> HalResult<i32> {
+        Self::all_with_module(self.module)
     }
 
-    pub fn get_pcm_solenoid_blacklist_with_module(module: i32) -> i32 {
+    pub fn pcm_solenoid_blacklist_with_module(module: i32) -> i32 {
         maybe_hal_call!(HAL_GetPCMSolenoidBlackList(module)).ok()
     }
 
-    pub fn get_pcm_solenoid_blacklist(&self) -> i32 {
-        Self::get_pcm_solenoid_blacklist_with_module(self.module)
+    pub fn pcm_solenoid_blacklist(&self) -> i32 {
+        Self::pcm_solenoid_blacklist_with_module(self.module)
     }
 
-    pub fn get_pcm_solenoid_voltage_sticky_fault_with_module(module: i32) -> bool {
+    pub fn pcm_solenoid_voltage_sticky_fault_with_module(module: i32) -> bool {
         maybe_hal_call!(HAL_GetPCMSolenoidVoltageStickyFault(module)).ok() != 0
     }
 
-    pub fn get_pcm_solenoid_voltage_sticky_fault(&self) -> bool {
-        Self::get_pcm_solenoid_voltage_sticky_fault_with_module(self.module)
+    pub fn pcm_solenoid_voltage_sticky_fault(&self) -> bool {
+        Self::pcm_solenoid_voltage_sticky_fault_with_module(self.module)
     }
 
-    pub fn get_pcm_solenoid_voltage_fault_with_module(module: i32) -> bool {
+    pub fn pcm_solenoid_voltage_fault_with_module(module: i32) -> bool {
         maybe_hal_call!(HAL_GetPCMSolenoidVoltageFault(module)).ok() != 0
     }
 
-    pub fn get_pcm_solenoid_voltage_fault(&self) -> bool {
-        Self::get_pcm_solenoid_voltage_fault_with_module(self.module)
+    pub fn pcm_solenoid_voltage_fault(&self) -> bool {
+        Self::pcm_solenoid_voltage_fault_with_module(self.module)
     }
 
     pub fn clear_all_pcm_sticky_faults_with_module(module: i32) {
@@ -123,7 +123,7 @@ impl Solenoid {
     }
 
     pub fn is_blacklisted(&self) -> bool {
-        (self.module.get_pcm_solenoid_blacklist() & (1 << self.channel)) != 0
+        (self.module.pcm_solenoid_blacklist() & (1 << self.channel)) != 0
     }
 
     pub fn set_pulse_duration(&self, seconds: f64) -> HalResult<()> {
@@ -263,19 +263,19 @@ impl Compressor {
         maybe_hal_call!(HAL_GetCompressor(self.compressor_handle)).ok() != 0
     }
 
-    pub fn get_pressure_switch_value(&self) -> bool {
+    pub fn pressure_switch_value(&self) -> bool {
         maybe_hal_call!(HAL_GetCompressorPressureSwitch(self.compressor_handle)).ok() != 0
     }
 
-    pub fn get_compressor_current(&self) -> f64 {
+    pub fn compressor_current(&self) -> f64 {
         maybe_hal_call!(HAL_GetCompressorCurrent(self.compressor_handle)).ok()
     }
 
-    pub fn get_closed_loop_control(&self) -> bool {
+    pub fn closed_loop_control(&self) -> bool {
         maybe_hal_call!(HAL_GetCompressorClosedLoopControl(self.compressor_handle)).ok() != 0
     }
 
-    pub fn get_compressor_current_too_high_fault(&self) -> bool {
+    pub fn compressor_current_too_high_fault(&self) -> bool {
         maybe_hal_call!(HAL_GetCompressorCurrentTooHighStickyFault(
             self.compressor_handle
         ))
@@ -283,7 +283,7 @@ impl Compressor {
             != 0
     }
 
-    pub fn get_compressor_current_too_high_sticky_fault(&self) -> bool {
+    pub fn compressor_current_too_high_sticky_fault(&self) -> bool {
         maybe_hal_call!(HAL_GetCompressorCurrentTooHighStickyFault(
             self.compressor_handle
         ))
@@ -291,15 +291,15 @@ impl Compressor {
             != 0
     }
 
-    pub fn get_compressor_shorted_sticky_fault(&self) -> bool {
+    pub fn compressor_shorted_sticky_fault(&self) -> bool {
         maybe_hal_call!(HAL_GetCompressorShortedStickyFault(self.compressor_handle)).ok() != 0
     }
 
-    pub fn get_compressor_shorted_fault(&self) -> bool {
+    pub fn compressor_shorted_fault(&self) -> bool {
         maybe_hal_call!(HAL_GetCompressorShortedFault(self.compressor_handle)).ok() != 0
     }
 
-    pub fn get_compressor_not_connected_sticky_fault(&self) -> bool {
+    pub fn compressor_not_connected_sticky_fault(&self) -> bool {
         maybe_hal_call!(HAL_GetCompressorNotConnectedStickyFault(
             self.compressor_handle
         ))
@@ -307,7 +307,7 @@ impl Compressor {
             != 0
     }
 
-    pub fn get_compressor_not_connected_fault(&self) -> bool {
+    pub fn compressor_not_connected_fault(&self) -> bool {
         maybe_hal_call!(HAL_GetCompressorNotConnectedFault(self.compressor_handle)).ok() != 0
     }
 

--- a/wpilib/src/pwm.rs
+++ b/wpilib/src/pwm.rs
@@ -46,7 +46,7 @@ impl PWM {
     }
 
     /// Get the PWM value directly from the hardware.
-    pub fn get_raw(&self) -> HalResult<i32> {
+    pub fn raw(&self) -> HalResult<i32> {
         hal_call!(HAL_GetPWMRaw(self.handle))
     }
 
@@ -56,7 +56,7 @@ impl PWM {
     }
 
     /// Get the PWM value in terms of a position.
-    pub fn get_position(&self) -> HalResult<f64> {
+    pub fn position(&self) -> HalResult<f64> {
         hal_call!(HAL_GetPWMPosition(self.handle))
     }
 
@@ -66,7 +66,7 @@ impl PWM {
     }
 
     /// Get the PWM value in terms of speed.
-    pub fn get_speed(&self) -> HalResult<f64> {
+    pub fn speed(&self) -> HalResult<f64> {
         hal_call!(HAL_GetPWMSpeed(self.handle))
     }
 
@@ -138,7 +138,7 @@ impl PWM {
     /// Get the bounds on the PWM values. This Gets the bounds on the PWM values for a particular
     /// each type of controller. The values determine the upper and lower speeds as well as the
     /// deadband bracket.
-    pub fn get_raw_bounds(
+    pub fn raw_bounds(
         &self,
         max: &mut i32,
         deadband_max: &mut i32,
@@ -157,7 +157,7 @@ impl PWM {
     }
 
     /// Get the channel of this device.
-    pub fn get_channel(&self) -> i32 {
+    pub fn channel(&self) -> i32 {
         self.channel
     }
 }
@@ -210,9 +210,9 @@ impl PwmSpeedController {
     /// Get the recently set value of the PWM.
     pub fn get(&self) -> HalResult<f64> {
         if self.inverted {
-            Ok(-self.pwm.get_speed()?)
+            Ok(-self.pwm.speed()?)
         } else {
-            self.pwm.get_speed()
+            self.pwm.speed()
         }
     }
 
@@ -222,7 +222,7 @@ impl PwmSpeedController {
     }
 
     /// Gets if the PWM is being inverted.
-    pub fn get_inverted(&self) -> bool {
+    pub fn inverted(&self) -> bool {
         self.inverted
     }
 

--- a/wpilib/src/robot_base.rs
+++ b/wpilib/src/robot_base.rs
@@ -63,7 +63,7 @@ impl RobotBase {
         println!("\n********** Robot program starting **********\n");
     }
 
-    pub fn get_ds_instance(&self) -> ThreadSafeDs {
+    pub fn ds_instance(&self) -> ThreadSafeDs {
         self.ds.clone()
     }
 
@@ -71,7 +71,7 @@ impl RobotBase {
     ///
     /// For now, expect this to be competition year.
     #[inline(always)]
-    pub fn get_fpga_version() -> HalResult<i32> {
+    pub fn fpga_version() -> HalResult<i32> {
         hal_call!(HAL_GetFPGAVersion())
     }
 
@@ -81,7 +81,7 @@ impl RobotBase {
     /// Major Revision. The next 8 bits are the Minor Revision. The 12 least
     /// significant bits are the Build Number.
     #[inline(always)]
-    pub fn get_fpga_revision() -> HalResult<i64> {
+    pub fn fpga_revision() -> HalResult<i64> {
         hal_call!(HAL_GetFPGARevision())
     }
 
@@ -122,7 +122,7 @@ impl RobotBase {
     }
 
     /// Get the robot's current battery voltage.
-    pub fn get_battery_voltage() -> HalResult<f64> {
+    pub fn battery_voltage() -> HalResult<f64> {
         hal_call!(HAL_GetVinVoltage())
     }
 }

--- a/wpilib/src/serial.rs
+++ b/wpilib/src/serial.rs
@@ -118,7 +118,7 @@ impl SerialPort {
         hal_call!(HAL_DisableSerialTermination(self.port as HAL_SerialPort))
     }
 
-    pub fn get_bytes_received(&mut self) -> HalResult<i32> {
+    pub fn bytes_received(&mut self) -> HalResult<i32> {
         hal_call!(HAL_GetSerialBytesReceived(self.port as HAL_SerialPort))
     }
 

--- a/wpilib/src/spi.rs
+++ b/wpilib/src/spi.rs
@@ -155,7 +155,7 @@ impl Spi {
         ))
     }
 
-    pub fn get_auto_dropped_count(&mut self) -> HalResult<i32> {
+    pub fn auto_dropped_count(&mut self) -> HalResult<i32> {
         hal_call!(HAL_GetSPIAutoDroppedCount(self.port))
     }
 }


### PR DESCRIPTION
This would bring this project into compliance with [C-GETTERS](https://rust-lang-nursery.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter) from the Rust API Guidelines. Note that this is a breaking change; I will change this deprecate the old methods instead if you want, but think that given that the project is still in alpha it's probably not necessary. Note that your next release after merging this would, as it stands, need to be SEMVER-MINOR.