### PR TITLE
Declare concat_idents feature appropriately

### DIFF
--- a/wpilib-sys/src/lib.rs
+++ b/wpilib-sys/src/lib.rs
@@ -5,7 +5,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(concat_idents)]
 pub mod bindings;
 pub mod hal_call;
 pub mod usage;

--- a/wpilib-sys/src/usage.rs
+++ b/wpilib-sys/src/usage.rs
@@ -47,6 +47,8 @@ pub type UsageResourceInstance = nUsageReporting_tInstances;
 /// Currently, the identifier for a digital output is
 /// `nUsageReporting_tResourceType_kResourceType_DigitalOutput`.
 /// This is equivalent to `resource_type!(DigitalOutput)`.
+///
+/// This currently requires the `concat_idents` feature.
 #[macro_export]
 macro_rules! resource_type {
     ($resource_name:ident) => {
@@ -58,6 +60,8 @@ macro_rules! resource_type {
 /// Currently, the identifier for the C++ language is
 /// `nUsageReporting_tInstances_kLanguage_CPlusPlus`.
 /// This is equivalent to `resource_instance!(Language, CPlusPLus)`.
+///
+/// This currently requires the `concat_idents` feature.
 #[macro_export]
 macro_rules! resource_instance {
     ($resource_name:ident, $instance_name:ident) => {


### PR DESCRIPTION
Only the crates using the macros that use concat_idents need to enable
the concat_idents feature, not the crate that defines the macro.

This allows wpilib-sys to build on beta.

Also document that the macros require the concat_idents feature.