### PR TITLE
Make usage reporting safe

### DIFF
--- a/wpilib-examples/custom_usage.rs
+++ b/wpilib-examples/custom_usage.rs
@@ -23,7 +23,8 @@ impl UsageReported {
             resource_type!(Language),
             resource_instance!(Language, CPlusPlus),
         );
-        unsafe { report_usage_extras(9998, 9998, 9997, b"FEATURE".as_ptr()) };
+        report_usage_context(666, 0, 123);
+        report_usage_extras(9998, 9998, 9997, b"FEATURE");
         Self {}
     }
 }

--- a/wpilib-examples/custom_usage.rs
+++ b/wpilib-examples/custom_usage.rs
@@ -24,7 +24,7 @@ impl UsageReported {
             resource_instance!(Language, CPlusPlus),
         );
         report_usage_context(666, 0, 123);
-        report_usage_extras(9998, 9998, 9997, b"FEATURE");
+        report_usage_extras(9998, 9998, 9997, b"FEATURE\0");
         Self {}
     }
 }

--- a/wpilib-sys/src/usage.rs
+++ b/wpilib-sys/src/usage.rs
@@ -34,6 +34,7 @@ except according to those terms.
 use super::bindings::HALUsageReporting_tInstances;
 use super::bindings::HALUsageReporting_tResourceType;
 use super::bindings::HAL_Report;
+use std::ffi::CStr;
 use std::os::raw;
 use std::ptr;
 
@@ -80,19 +81,28 @@ macro_rules! resource_instance {
 /// Report the usage of a specific resource type with an `instance` value attached.
 ///
 /// This is provided as a utility for library developers.
-pub fn report_usage(resource: UsageResourceType, instance: UsageResourceInstance) {
-    unsafe {
-        HAL_Report(resource as i32, instance as i32, 0, ptr::null());
-    }
+pub fn report_usage(resource: UsageResourceType, instance: UsageResourceInstance) -> i64 {
+    report_usage_context(resource, instance, 0)
 }
 
+/// Report usage of a resource with additional context.
+///
 /// This is provided as a utility for library developers.
-/// Pass `ptr::null()` for `feature` to exclude it.
-pub unsafe fn report_usage_extras(
+pub fn report_usage_context(
     resource: UsageResourceType,
     instance: UsageResourceInstance,
     context: i32,
-    feature: *const raw::c_char,
-) {
-    HAL_Report(resource as i32, instance as i32, context, feature);
+) -> i64 {
+    unsafe { HAL_Report(resource as i32, instance as i32, context, ptr::null()) }
+}
+
+/// This is provided as a utility for library developers.
+pub fn report_usage_extras(
+    resource: UsageResourceType,
+    instance: UsageResourceInstance,
+    context: i32,
+    feature: impl Into<AsRef<CStr>>,
+) -> i64 {
+    let feature = feature.into().as_ref();
+    unsafe { HAL_Report(resource as i32, instance as i32, context, feature.as_ptr()) }
 }

--- a/wpilib/src/encoder.rs
+++ b/wpilib/src/encoder.rs
@@ -34,7 +34,6 @@ License version 3 as published by the Free Software Foundation. See
 use wpilib_sys::*;
 
 use crate::dio::DigitalInput;
-use std::ptr;
 
 /// The indexing type for an encoder
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -111,14 +110,11 @@ impl Encoder {
             encoder: handle,
         };
 
-        unsafe {
-            report_usage_extras(
-                resource_type!(Encoder),
-                encoder.fpga_index()? as u32,
-                encoding.into_hal(),
-                ptr::null(),
-            );
-        }
+        report_usage_context(
+            resource_type!(Encoder),
+            encoder.fpga_index()? as u32,
+            encoding.into_hal(),
+        );
 
         Ok(encoder)
     }

--- a/wpilib/src/pneumatics.rs
+++ b/wpilib/src/pneumatics.rs
@@ -6,7 +6,6 @@
 // except according to those terms.
 
 use super::sensor_util;
-use std::ptr;
 use wpilib_sys::*;
 
 /// Corresponds to WPILibC's SolenoidBase, and is responsible for
@@ -95,14 +94,11 @@ impl Solenoid {
             channel
         )))?;
 
-        unsafe {
-            report_usage_extras(
-                resource_type!(Solenoid),
-                channel as UsageResourceType,
-                module_number,
-                ptr::null(),
-            );
-        }
+        report_usage_context(
+            resource_type!(Solenoid),
+            channel as UsageResourceType,
+            module_number,
+        );
 
         Ok(Solenoid {
             solenoid_handle: handle,


### PR DESCRIPTION
HAL_Report expects a null-terminated string to be passed as feature.
This ensures that a valid UTF-8 null-terminated string is passed in,
making report_usage_extras a safe wrapper around HAL_Report.

This also adds a report_usage_context function to allow for the
otherwise lost ability to pass in a null pointer as feature.

Also return the return value of HAL_Report, in case anyone actually
finds it useful.