### PR TITLE
usage: Avoid forcing users to use all the HAL

### DIFF
--- a/wpilib-examples/custom_usage.rs
+++ b/wpilib-examples/custom_usage.rs
@@ -11,8 +11,6 @@
 #[macro_use]
 extern crate wpilib_sys;
 
-// Pull in the usage reporting constants themselves.
-use wpilib_sys::bindings::*;
 use wpilib_sys::usage::*;
 
 struct UsageReported {}

--- a/wpilib-sys/Cargo.toml
+++ b/wpilib-sys/Cargo.toml
@@ -28,4 +28,4 @@ include = [
 dev = []
 
 [build-dependencies]
-bindgen = "0.37.4"
+bindgen = "0.43.1"

--- a/wpilib-sys/build.rs
+++ b/wpilib-sys/build.rs
@@ -99,6 +99,7 @@ fn generate_bindings() {
         // usage reporting enums
         .whitelist_type(".*tInstances")
         .whitelist_type(".*tResourceType")
+        .constified_enum_module("*")
         .clang_arg(format!("-I{}", INCLUDE_DIR))
         .clang_arg("-x")
         .clang_arg("c++")

--- a/wpilib-sys/build.rs
+++ b/wpilib-sys/build.rs
@@ -89,8 +89,6 @@ fn always_run() {
 fn generate_bindings() {
     const INCLUDE_DIR: &'static str = "include";
     const SYMBOL_REGEX: &'static str = "HAL_[A-Za-z0-9]+";
-    // Not needed due to `always-run()`
-    // println!("cargo:rerun-if-changed={}/*", INCLUDE_DIR);
     let bindings = bindgen::Builder::default()
         .derive_default(true)
         .rustfmt_bindings(false)

--- a/wpilib-sys/src/lib.rs
+++ b/wpilib-sys/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(concat_idents)]
+
 // Copyright 2018 First Rust Competition Developers.
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/wpilib-sys/src/lib.rs
+++ b/wpilib-sys/src/lib.rs
@@ -1,11 +1,12 @@
-#![feature(concat_idents)]
-
 // Copyright 2018 First Rust Competition Developers.
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// uncomment for testing the usage macros
+// #![feature(concat_idents)]
 
 pub mod bindings;
 pub mod hal_call;

--- a/wpilib-sys/src/usage.rs
+++ b/wpilib-sys/src/usage.rs
@@ -51,12 +51,13 @@ pub type UsageResourceInstance = HALUsageReporting_tInstances;
 /// This currently requires the `concat_idents` feature.
 #[macro_export]
 macro_rules! resource_type {
-    ($resource_name:ident) => {
+    ($resource_name:ident) => {{
+        use $crate::bindings::*;
         concat_idents!(
             HALUsageReporting_tResourceType_kResourceType_,
             $resource_name
         )
-    };
+    }};
 }
 
 /// A utility macro for referencing rust-bindgen's generated names for usage instances.
@@ -67,14 +68,15 @@ macro_rules! resource_type {
 /// This currently requires the `concat_idents` feature.
 #[macro_export]
 macro_rules! resource_instance {
-    ($resource_name:ident, $instance_name:ident) => {
+    ($resource_name:ident, $instance_name:ident) => {{
+        use $crate::bindings::*;
         concat_idents!(
             HALUsageReporting_tInstances_k,
             $resource_name,
             _,
             $instance_name
         )
-    };
+    }};
 }
 
 /// Report the usage of a specific resource type with an `instance` value attached.

--- a/wpilib-sys/src/usage.rs
+++ b/wpilib-sys/src/usage.rs
@@ -44,49 +44,39 @@ pub type UsageResourceType = HALUsageReporting_tResourceType::Type;
 pub type UsageResourceInstance = HALUsageReporting_tInstances::Type;
 
 /// A utility macro for referencing rust-bindgen's generated names for usage types.
-/// Currently, the identifier for a digital output is
-/// `HALUsageReporting_tResourceType_kResourceType_DigitalOutput`.
-/// This is equivalent to `resource_type!(DigitalOutput)`.
+///
+/// ```
+/// assert_eq!(
+///   HALUsageReporting_tResourceType::kResourceType_DigitalOutput,
+///   resource_type!(DigitalOutput)
+/// );
+/// ```
 ///
 /// This currently requires the `concat_idents` feature.
 #[macro_export]
 macro_rules! resource_type {
     ($resource_name:ident) => {{
-        use $crate::bindings::*;
-        concat_idents!(
-            $crate::bindings::HALUsageReporting_tResourceType::kResourceType_,
-            $resource_name
-        )
+        use $crate::bindings::HALUsageReporting_tResourceType::*;
+        concat_idents!(kResourceType_, $resource_name)
     }};
 }
 
 /// A utility macro for referencing rust-bindgen's generated names for usage instances.
 ///
-/// #```
-/// use bindings::*;
-/// assert_eq!(HALUsageReporting_tInstances::kLanguage_CPlusPlus, resource_instance!(Language, CPlusPlus));
-/// #```
+/// ```
+/// assert_eq!(
+///   HALUsageReporting_tInstances::kLanguage_CPlusPlus,
+///   resource_instance!(Language, CPlusPlus)
+/// );
+/// ```
 ///
 /// This currently requires the `concat_idents` feature.
 #[macro_export]
 macro_rules! resource_instance {
     ($resource_name:ident, $instance_name:ident) => {{
-        use $crate::bindings::*;
-        concat_idents!(
-            $crate::bindings::HALUsageReporting_tInstances::k,
-            $resource_name,
-            _,
-            $instance_name
-        )
+        use $crate::bindings::HALUsageReporting_tInstances::*;
+        concat_idents!(k, $resource_name, _, $instance_name)
     }};
-}
-
-#[test]
-fn test() {
-    assert_eq!(
-        HALUsageReporting_tInstances::kLanguage_CPlusPlus,
-        resource_instance!(Language, CPlusPlus)
-    );
 }
 
 /// Report the usage of a specific resource type with an `instance` value attached.

--- a/wpilib-sys/src/usage.rs
+++ b/wpilib-sys/src/usage.rs
@@ -38,10 +38,10 @@ use std::os::raw;
 use std::ptr;
 
 /// Wraps the ugly type rust-bindgen generates for usage reporting types.
-pub type UsageResourceType = HALUsageReporting_tResourceType;
+pub type UsageResourceType = HALUsageReporting_tResourceType::Type;
 
 /// Wraps the ugly type rust-bindgen generates for usage reporting instances.
-pub type UsageResourceInstance = HALUsageReporting_tInstances;
+pub type UsageResourceInstance = HALUsageReporting_tInstances::Type;
 
 /// A utility macro for referencing rust-bindgen's generated names for usage types.
 /// Currently, the identifier for a digital output is
@@ -54,16 +54,18 @@ macro_rules! resource_type {
     ($resource_name:ident) => {{
         use $crate::bindings::*;
         concat_idents!(
-            HALUsageReporting_tResourceType_kResourceType_,
+            $crate::bindings::HALUsageReporting_tResourceType::kResourceType_,
             $resource_name
         )
     }};
 }
 
 /// A utility macro for referencing rust-bindgen's generated names for usage instances.
-/// Currently, the identifier for the C++ language is
-/// `HALUsageReporting_tInstances_kLanguage_CPlusPlus`.
-/// This is equivalent to `resource_instance!(Language, CPlusPLus)`.
+///
+/// #```
+/// use bindings::*;
+/// assert_eq!(HALUsageReporting_tInstances::kLanguage_CPlusPlus, resource_instance!(Language, CPlusPlus));
+/// #```
 ///
 /// This currently requires the `concat_idents` feature.
 #[macro_export]
@@ -71,12 +73,20 @@ macro_rules! resource_instance {
     ($resource_name:ident, $instance_name:ident) => {{
         use $crate::bindings::*;
         concat_idents!(
-            HALUsageReporting_tInstances_k,
+            $crate::bindings::HALUsageReporting_tInstances::k,
             $resource_name,
             _,
             $instance_name
         )
     }};
+}
+
+#[test]
+fn test() {
+    assert_eq!(
+        HALUsageReporting_tInstances::kLanguage_CPlusPlus,
+        resource_instance!(Language, CPlusPlus)
+    );
 }
 
 /// Report the usage of a specific resource type with an `instance` value attached.

--- a/wpilib/Cargo.toml
+++ b/wpilib/Cargo.toml
@@ -30,6 +30,3 @@ dev = []
 [dependencies]
 lazy_static = "1.1.0"
 wpilib-sys = {path = "../wpilib-sys", version = "0.2.3"}
-
-[build-dependencies]
-bindgen = "0.37.4"

--- a/wpilib/src/ds.rs
+++ b/wpilib/src/ds.rs
@@ -138,6 +138,7 @@ impl From<HAL_MatchInfo> for MatchInfoData {
         let mut cs = info.eventName;
         cs[cs.len() - 1] = 0;
 
+        use self::HAL_MatchType::*;
         Self {
             event_name: unsafe { CStr::from_ptr(&cs as *const c_char) }
                 .to_string_lossy()
@@ -148,9 +149,9 @@ impl From<HAL_MatchInfo> for MatchInfoData {
             match_number: info.matchNumber,
             replay_number: info.replayNumber,
             match_type: match info.matchType {
-                HAL_MatchType_HAL_kMatchType_practice => MatchType::Practice,
-                HAL_MatchType_HAL_kMatchType_qualification => MatchType::Qualification,
-                HAL_MatchType_HAL_kMatchType_elimination => MatchType::Elimination,
+                HAL_kMatchType_practice => MatchType::Practice,
+                HAL_kMatchType_qualification => MatchType::Qualification,
+                HAL_kMatchType_elimination => MatchType::Elimination,
                 _ => MatchType::None,
             },
         }
@@ -229,13 +230,14 @@ impl<'a> DriverStation<'a> {
     /// The alliance the robot is on.
     #[allow(non_upper_case_globals)]
     pub fn alliance(&self) -> HalResult<Alliance> {
+        use self::HAL_AllianceStationID::*;
         match hal_call!(HAL_GetAllianceStation())? {
-            HAL_AllianceStationID_HAL_AllianceStationID_kRed1
-            | HAL_AllianceStationID_HAL_AllianceStationID_kRed2
-            | HAL_AllianceStationID_HAL_AllianceStationID_kRed3 => Ok(Alliance::Red),
-            HAL_AllianceStationID_HAL_AllianceStationID_kBlue1
-            | HAL_AllianceStationID_HAL_AllianceStationID_kBlue2
-            | HAL_AllianceStationID_HAL_AllianceStationID_kBlue3 => Ok(Alliance::Blue),
+            HAL_AllianceStationID_kRed1
+            | HAL_AllianceStationID_kRed2
+            | HAL_AllianceStationID_kRed3 => Ok(Alliance::Red),
+            HAL_AllianceStationID_kBlue1
+            | HAL_AllianceStationID_kBlue2
+            | HAL_AllianceStationID_kBlue3 => Ok(Alliance::Blue),
             _ => Err(HalError(0)),
         }
     }
@@ -243,13 +245,11 @@ impl<'a> DriverStation<'a> {
     /// The id for the station the driver station is at, as an integer.
     #[allow(non_upper_case_globals)]
     pub fn station(&self) -> HalResult<u32> {
+        use self::HAL_AllianceStationID::*;
         match hal_call!(HAL_GetAllianceStation())? {
-            HAL_AllianceStationID_HAL_AllianceStationID_kRed1
-            | HAL_AllianceStationID_HAL_AllianceStationID_kBlue1 => Ok(1),
-            HAL_AllianceStationID_HAL_AllianceStationID_kRed2
-            | HAL_AllianceStationID_HAL_AllianceStationID_kBlue2 => Ok(2),
-            HAL_AllianceStationID_HAL_AllianceStationID_kRed3
-            | HAL_AllianceStationID_HAL_AllianceStationID_kBlue3 => Ok(3),
+            HAL_AllianceStationID_kRed1 | HAL_AllianceStationID_kBlue1 => Ok(1),
+            HAL_AllianceStationID_kRed2 | HAL_AllianceStationID_kBlue2 => Ok(2),
+            HAL_AllianceStationID_kRed3 | HAL_AllianceStationID_kBlue3 => Ok(3),
             _ => Err(HalError(0)),
         }
     }

--- a/wpilib/src/encoder.rs
+++ b/wpilib/src/encoder.rs
@@ -47,13 +47,13 @@ pub enum IndexingType {
 
 impl IndexingType {
     #[allow(dead_code)]
-    pub(crate) fn into_hal(self) -> HAL_EncoderIndexingType {
+    pub(crate) fn into_hal(self) -> HAL_EncoderIndexingType::Type {
         use self::IndexingType::*;
         match self {
-            ResetWhileHigh => HAL_EncoderIndexingType_HAL_kResetWhileHigh,
-            ResetWhileLow => HAL_EncoderIndexingType_HAL_kResetWhileLow,
-            ResetOnFallingEdge => HAL_EncoderIndexingType_HAL_kResetOnFallingEdge,
-            ResetOnRisingEdge => HAL_EncoderIndexingType_HAL_kResetOnRisingEdge,
+            ResetWhileHigh => HAL_EncoderIndexingType::HAL_kResetWhileHigh,
+            ResetWhileLow => HAL_EncoderIndexingType::HAL_kResetWhileLow,
+            ResetOnFallingEdge => HAL_EncoderIndexingType::HAL_kResetOnFallingEdge,
+            ResetOnRisingEdge => HAL_EncoderIndexingType::HAL_kResetOnRisingEdge,
         }
     }
 }
@@ -66,12 +66,12 @@ pub enum EncodingType {
 }
 
 impl EncodingType {
-    pub(crate) fn into_hal(self) -> HAL_EncoderEncodingType {
+    pub(crate) fn into_hal(self) -> HAL_EncoderEncodingType::Type {
         use self::EncodingType::*;
         match self {
-            K1X => HAL_EncoderEncodingType_HAL_Encoder_k1X,
-            K2X => HAL_EncoderEncodingType_HAL_Encoder_k2X,
-            K4X => HAL_EncoderEncodingType_HAL_Encoder_k4X,
+            K1X => HAL_EncoderEncodingType::HAL_Encoder_k1X,
+            K2X => HAL_EncoderEncodingType::HAL_Encoder_k2X,
+            K4X => HAL_EncoderEncodingType::HAL_Encoder_k4X,
         }
     }
 }

--- a/wpilib/src/serial.rs
+++ b/wpilib/src/serial.rs
@@ -74,19 +74,22 @@ impl SerialPort {
         parity: Parity,
         stopbits: StopBits,
     ) -> HalResult<Self> {
-        hal_call!(HAL_InitializeSerialPort(port as HAL_SerialPort))?;
+        hal_call!(HAL_InitializeSerialPort(port as HAL_SerialPort::Type))?;
 
         hal_call!(HAL_SetSerialBaudRate(
-            port as HAL_SerialPort,
+            port as HAL_SerialPort::Type,
             baud_rate as i32
         ))?;
         hal_call!(HAL_SetSerialDataBits(
-            port as HAL_SerialPort,
+            port as HAL_SerialPort::Type,
             databits as i32
         ))?;
-        hal_call!(HAL_SetSerialParity(port as HAL_SerialPort, parity as i32))?;
+        hal_call!(HAL_SetSerialParity(
+            port as HAL_SerialPort::Type,
+            parity as i32
+        ))?;
         hal_call!(HAL_SetSerialStopBits(
-            port as HAL_SerialPort,
+            port as HAL_SerialPort::Type,
             stopbits as i32
         ))?;
 
@@ -103,29 +106,33 @@ impl SerialPort {
 
     pub fn set_flow_control(&mut self, flow_control: FlowControl) -> HalResult<()> {
         hal_call!(HAL_SetSerialFlowControl(
-            self.port as HAL_SerialPort,
+            self.port as HAL_SerialPort::Type,
             flow_control as i32
         ))
     }
 
     pub fn enable_termination(&mut self, terminator: byte) -> HalResult<()> {
         hal_call!(HAL_EnableSerialTermination(
-            self.port as HAL_SerialPort,
+            self.port as HAL_SerialPort::Type,
             terminator
         ))
     }
 
     pub fn disable_termination(&mut self) -> HalResult<()> {
-        hal_call!(HAL_DisableSerialTermination(self.port as HAL_SerialPort))
+        hal_call!(HAL_DisableSerialTermination(
+            self.port as HAL_SerialPort::Type
+        ))
     }
 
     pub fn bytes_received(&mut self) -> HalResult<i32> {
-        hal_call!(HAL_GetSerialBytesReceived(self.port as HAL_SerialPort))
+        hal_call!(HAL_GetSerialBytesReceived(
+            self.port as HAL_SerialPort::Type
+        ))
     }
 
     pub fn read(&mut self, buf: &mut [byte]) -> HalResult<i32> {
         hal_call!(HAL_ReadSerial(
-            self.port as HAL_SerialPort,
+            self.port as HAL_SerialPort::Type,
             buf.as_mut_ptr(),
             buf.len() as i32
         ))
@@ -134,7 +141,7 @@ impl SerialPort {
     pub fn read_len(&mut self, buf: &mut [byte], len: usize) -> HalResult<i32> {
         let len = len.min(buf.len());
         hal_call!(HAL_ReadSerial(
-            self.port as HAL_SerialPort,
+            self.port as HAL_SerialPort::Type,
             buf.as_mut_ptr(),
             len as i32
         ))
@@ -144,48 +151,51 @@ impl SerialPort {
     /// Then number of bytes actually written to the buffer.
     pub fn write(&mut self, buf: &[byte]) -> HalResult<i32> {
         hal_call!(HAL_WriteSerial(
-            self.port as HAL_SerialPort,
+            self.port as HAL_SerialPort::Type,
             buf.as_ptr(),
             buf.len() as i32
         ))
     }
 
     pub fn set_timeout(&mut self, seconds: f64) -> HalResult<()> {
-        hal_call!(HAL_SetSerialTimeout(self.port as HAL_SerialPort, seconds))
+        hal_call!(HAL_SetSerialTimeout(
+            self.port as HAL_SerialPort::Type,
+            seconds
+        ))
     }
 
     pub fn set_read_buf_size(&mut self, size: u32) -> HalResult<()> {
         hal_call!(HAL_SetSerialReadBufferSize(
-            self.port as HAL_SerialPort,
+            self.port as HAL_SerialPort::Type,
             size as i32
         ))
     }
 
     pub fn set_write_buf_size(&mut self, size: u32) -> HalResult<()> {
         hal_call!(HAL_SetSerialWriteBufferSize(
-            self.port as HAL_SerialPort,
+            self.port as HAL_SerialPort::Type,
             size as i32
         ))
     }
 
     pub fn set_write_buf_mode(&mut self, mode: WriteBufferMode) -> HalResult<()> {
         hal_call!(HAL_SetSerialWriteMode(
-            self.port as HAL_SerialPort,
+            self.port as HAL_SerialPort::Type,
             mode as i32
         ))
     }
 
     pub fn flush(&mut self) -> HalResult<()> {
-        hal_call!(HAL_FlushSerial(self.port as HAL_SerialPort))
+        hal_call!(HAL_FlushSerial(self.port as HAL_SerialPort::Type))
     }
 
     pub fn reset(&mut self) -> HalResult<()> {
-        hal_call!(HAL_ClearSerial(self.port as HAL_SerialPort))
+        hal_call!(HAL_ClearSerial(self.port as HAL_SerialPort::Type))
     }
 }
 
 impl Drop for SerialPort {
     fn drop(&mut self) {
-        hal_call!(HAL_CloseSerial(self.port as HAL_SerialPort)).ok();
+        hal_call!(HAL_CloseSerial(self.port as HAL_SerialPort::Type)).ok();
     }
 }

--- a/wpilib/src/spi.rs
+++ b/wpilib/src/spi.rs
@@ -19,7 +19,7 @@ pub enum Port {
 /// Spi for driver writers. Currenltly does not include an accumulator.
 #[derive(Debug)]
 pub struct Spi {
-    port: HAL_SPIPort,
+    port: HAL_SPIPort::Type,
     msb_first: bool,
     sample_on_trailing: bool,
     clk_idle_high: bool,
@@ -28,10 +28,10 @@ pub struct Spi {
 impl Spi {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(port: Port) -> HalResult<Self> {
-        hal_call!(HAL_InitializeSPI(port as HAL_SPIPort))?;
+        hal_call!(HAL_InitializeSPI(port as HAL_SPIPort::Type))?;
         report_usage(resource_type!(SPI), 1);
         Ok(Spi {
-            port: port as HAL_SPIPort,
+            port: port as HAL_SPIPort::Type,
             msb_first: false,
             sample_on_trailing: false,
             clk_idle_high: false,


### PR DESCRIPTION
This changes the resource_type! and resource_instance! macros to use
bindings::* instead of depending on the user to pull them in themselves.