### PR TITLE
Avoid panicking in report_usage_extras

### DIFF
--- a/wpilib-examples/custom_usage.rs
+++ b/wpilib-examples/custom_usage.rs
@@ -22,7 +22,7 @@ impl UsageReported {
             resource_instance!(Language, CPlusPlus),
         );
         report_usage_context(666, 0, 123);
-        report_usage_extras(9998, 9998, 9997, b"FEATURE\0");
+        report_usage_extras(9998, 9998, 9997, CStr::from_bytes_with_nul("FEATURE\0").unwrap();
         Self {}
     }
 }

--- a/wpilib-sys/src/usage.rs
+++ b/wpilib-sys/src/usage.rs
@@ -97,19 +97,14 @@ pub fn report_usage_context(
     unsafe { HAL_Report(resource as i32, instance as i32, context, ptr::null()) }
 }
 
-/// This is provided as a utility for library developers.
-/// Designed to be used with null-terminated byte string literals like `b"message\0"`
+/// Report usage of an additional feature.
 ///
-/// # Panics
-/// If the underlying byte slice is not null-terminated, the function will panic
-pub fn report_usage_extras<F: AsRef<[u8]>>(
+/// This is provided as a utility for library developers.
+pub fn report_usage_extras(
     resource: UsageResourceType,
     instance: UsageResourceInstance,
     context: i32,
-    feature: F,
+    feature: CStr,
 ) -> i64 {
-    // local binding just to be safe with lifetimes, see https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.as_ptr
-    let cstr = CStr::from_bytes_with_nul(feature.as_ref())
-        .expect("report_usage_extras features must be null-terminated!");
-    unsafe { HAL_Report(resource as i32, instance as i32, context, cstr.as_ptr()) }
+    unsafe { HAL_Report(resource as i32, instance as i32, context, feature.as_ptr()) }
 }


### PR DESCRIPTION
Per the [Rust API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/dependability.html#static-enforcement), static enforcement is almost always preferable to runtime failure. A CStr forces the user to guarantee that the string is null-terminated, and is thus better than panicking.

Note: this is breaking change.