### PR TITLE
Make HAL enums DRYer

### DIFF
--- a/wpilib-sys/src/usage.rs
+++ b/wpilib-sys/src/usage.rs
@@ -31,43 +31,38 @@ except according to those terms.
 */
 
 #![macro_use]
-use super::bindings::HALUsageReporting_tInstances;
-use super::bindings::HALUsageReporting_tResourceType;
 use super::bindings::HAL_Report;
 use std::ffi::CStr;
 use std::ptr;
 
+pub use super::bindings::HALUsageReporting_tResourceType as resource_types;
+pub use super::bindings::HALUsageReporting_tInstances as instances;
+
 /// Wraps the ugly type rust-bindgen generates for usage reporting types.
-pub type UsageResourceType = HALUsageReporting_tResourceType::Type;
+pub type UsageResourceType = resource_types::Type;
 
 /// Wraps the ugly type rust-bindgen generates for usage reporting instances.
-pub type UsageResourceInstance = HALUsageReporting_tInstances::Type;
+pub type UsageResourceInstance = instances::Type;
 
 /// A utility macro for referencing rust-bindgen's generated names for usage types.
 ///
-/// ```
-/// assert_eq!(
-///   HALUsageReporting_tResourceType::kResourceType_DigitalOutput,
-///   resource_type!(DigitalOutput)
-/// );
-/// ```
+/// Preserved for backwards compatibility. Users are recommended to
+/// reference `resource_types` directly.
 ///
-/// This currently requires the `concat_idents` feature.
+/// ```
+/// assert_eq!(resource_types::DigitalOutput, resource_type!(DigitalOutput));
+/// ```
 #[macro_export]
 macro_rules! resource_type {
-    ($resource_name:ident) => {{
-        use $crate::bindings::HALUsageReporting_tResourceType::*;
-        concat_idents!(kResourceType_, $resource_name)
-    }};
+    ($resource_name:ident) => {
+        $crate::bindings::HALUsageReporting_tResourceType::$resource_name
+    };
 }
 
 /// A utility macro for referencing rust-bindgen's generated names for usage instances.
 ///
 /// ```
-/// assert_eq!(
-///   HALUsageReporting_tInstances::kLanguage_CPlusPlus,
-///   resource_instance!(Language, CPlusPlus)
-/// );
+/// assert_eq!(instances::kLanguage_CPlusPlus, resource_instance!(Language, CPlusPlus));
 /// ```
 ///
 /// This currently requires the `concat_idents` feature.

--- a/wpilib/src/ds.rs
+++ b/wpilib/src/ds.rs
@@ -232,12 +232,8 @@ impl<'a> DriverStation<'a> {
     pub fn alliance(&self) -> HalResult<Alliance> {
         use self::HAL_AllianceStationID::*;
         match hal_call!(HAL_GetAllianceStation())? {
-            HAL_AllianceStationID_kRed1
-            | HAL_AllianceStationID_kRed2
-            | HAL_AllianceStationID_kRed3 => Ok(Alliance::Red),
-            HAL_AllianceStationID_kBlue1
-            | HAL_AllianceStationID_kBlue2
-            | HAL_AllianceStationID_kBlue3 => Ok(Alliance::Blue),
+            kRed1 | kRed2 | kRed3 => Ok(Alliance::Red),
+            kBlue1 | kBlue2 | kBlue3 => Ok(Alliance::Blue),
             _ => Err(HalError(0)),
         }
     }
@@ -247,9 +243,9 @@ impl<'a> DriverStation<'a> {
     pub fn station(&self) -> HalResult<u32> {
         use self::HAL_AllianceStationID::*;
         match hal_call!(HAL_GetAllianceStation())? {
-            HAL_AllianceStationID_kRed1 | HAL_AllianceStationID_kBlue1 => Ok(1),
-            HAL_AllianceStationID_kRed2 | HAL_AllianceStationID_kBlue2 => Ok(2),
-            HAL_AllianceStationID_kRed3 | HAL_AllianceStationID_kBlue3 => Ok(3),
+            kRed1 | kBlue1 => Ok(1),
+            kRed2 | kBlue2 => Ok(2),
+            kRed3 | kBlue3 => Ok(3),
             _ => Err(HalError(0)),
         }
     }

--- a/wpilib/src/serial.rs
+++ b/wpilib/src/serial.rs
@@ -13,10 +13,10 @@ use wpilib_sys::*;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[repr(i32)]
 pub enum Port {
-    Onboard = HAL_SerialPort::HAL_SerialPort_Onboard,
-    MXP = HAL_SerialPort::HAL_SerialPort_MXP,
-    USB1 = HAL_SerialPort::HAL_SerialPort_USB1,
-    USB2 = HAL_SerialPort::HAL_SerialPort_USB2,
+    Onboard = HAL_SerialPort::Onboard,
+    MXP = HAL_SerialPort::MXP,
+    USB1 = HAL_SerialPort::USB1,
+    USB2 = HAL_SerialPort::USB2,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
- Rename variants in `HALUsageReporting::tResourceType` to not have a `kResourceType_` prefix.  This drops the `concat_idents` requirement for `resource_type!`.
- Rename variants in a couple of HAL enums to drop the enum name prefix.
- Re-export the usage reporting modules in `wpilib_sys::usage` with friendlier names.