### PR TITLE
Clean up usage reporting

### DIFF
--- a/wpilib-examples/custom_usage.rs
+++ b/wpilib-examples/custom_usage.rs
@@ -13,9 +13,9 @@ struct UsageReported {}
 
 impl UsageReported {
     pub fn new() -> Self {
-        report_usage(resource_types::Language, instances::kLanguage_CPlusPlus);
-        report_usage_context(666, 0, 123);
-        report_usage_extras(9998, 9998, 9997, b"FEATURE\0");
+        report(resource_types::Language, instances::kLanguage_CPlusPlus);
+        report_context(666, 0, 123);
+        report_extras(9998, 9998, 9997, b"FEATURE\0");
         Self {}
     }
 }

--- a/wpilib-examples/custom_usage.rs
+++ b/wpilib-examples/custom_usage.rs
@@ -7,6 +7,7 @@
 
 extern crate wpilib_sys;
 
+use std::ffi::CString;
 use wpilib_sys::usage::*;
 
 struct UsageReported {}
@@ -15,7 +16,7 @@ impl UsageReported {
     pub fn new() -> Self {
         report(resource_types::Language, instances::kLanguage_CPlusPlus);
         report_context(666, 0, 123);
-        report_extras(9998, 9998, 9997, b"FEATURE\0");
+        report_feature(9998, 9998, 9997, CString::new("FEATURE").unwrap());
         Self {}
     }
 }

--- a/wpilib-sys/src/lib.rs
+++ b/wpilib-sys/src/lib.rs
@@ -11,7 +11,6 @@ pub mod usage;
 
 pub use self::bindings::*;
 pub use self::hal_call::*;
-pub use self::usage::*;
 
 // version.rs is created by the makefile
 mod version;

--- a/wpilib-sys/src/usage.rs
+++ b/wpilib-sys/src/usage.rs
@@ -30,7 +30,8 @@ option. This file may not be copied, modified, or distributed
 except according to those terms.
 */
 
-#![macro_use]
+//! Lightweight wrappers around usage reporting.
+
 use super::bindings::HAL_Report;
 use std::ffi::CStr;
 use std::ptr;
@@ -41,14 +42,14 @@ pub use super::bindings::HALUsageReporting_tResourceType as resource_types;
 /// Report the usage of a specific resource type with an `instance` value attached.
 ///
 /// This is provided as a utility for library developers.
-pub fn report_usage(resource: resource_types::Type, instance: instances::Type) -> i64 {
-    report_usage_context(resource, instance, 0)
+pub fn report(resource: resource_types::Type, instance: instances::Type) -> i64 {
+    report_context(resource, instance, 0)
 }
 
 /// Report usage of a resource with additional context.
 ///
 /// This is provided as a utility for library developers.
-pub fn report_usage_context(
+pub fn report_context(
     resource: resource_types::Type,
     instance: instances::Type,
     context: i32,
@@ -61,7 +62,7 @@ pub fn report_usage_context(
 ///
 /// # Panics
 /// If the underlying byte slice is not null-terminated, the function will panic
-pub fn report_usage_extras<F: AsRef<[u8]>>(
+pub fn report_extras<F: AsRef<[u8]>>(
     resource: resource_types::Type,
     instance: instances::Type,
     context: i32,

--- a/wpilib-sys/src/usage.rs
+++ b/wpilib-sys/src/usage.rs
@@ -57,19 +57,21 @@ pub fn report_context(
     unsafe { HAL_Report(resource as i32, instance as i32, context, ptr::null()) }
 }
 
-/// This is provided as a utility for library developers.
-/// Designed to be used with null-terminated byte string literals like `b"message\0"`
+/// Report usage of a resource with context and a feature string.
 ///
-/// # Panics
-/// If the underlying byte slice is not null-terminated, the function will panic
-pub fn report_extras<F: AsRef<[u8]>>(
+/// This is provided as a utility for library developers.
+pub fn report_feature(
     resource: resource_types::Type,
     instance: instances::Type,
     context: i32,
-    feature: F,
+    feature: impl AsRef<CStr>,
 ) -> i64 {
-    // local binding just to be safe with lifetimes, see https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.as_ptr
-    let cstr = CStr::from_bytes_with_nul(feature.as_ref())
-        .expect("report_usage_extras features must be null-terminated!");
-    unsafe { HAL_Report(resource as i32, instance as i32, context, cstr.as_ptr()) }
+    unsafe {
+        HAL_Report(
+            resource as i32,
+            instance as i32,
+            context,
+            feature.as_ref().as_ptr(),
+        )
+    }
 }

--- a/wpilib/src/analog_input.rs
+++ b/wpilib/src/analog_input.rs
@@ -55,7 +55,7 @@ impl AnalogInput {
 
         let port = hal_call!(HAL_InitializeAnalogInputPort(HAL_GetPort(channel)))?;
 
-        report_usage(resource_types::AnalogChannel, channel as instances::Type);
+        usage::report(resource_types::AnalogChannel, channel as instances::Type);
 
         Ok(AnalogInput {
             channel,

--- a/wpilib/src/dio.rs
+++ b/wpilib/src/dio.rs
@@ -57,7 +57,7 @@ impl DigitalOutput {
             false as i32 // for input?
         ))?;
 
-        report_usage(resource_types::DigitalOutput, channel as instances::Type);
+        usage::report(resource_types::DigitalOutput, channel as instances::Type);
 
         Ok(DigitalOutput {
             channel,
@@ -172,7 +172,7 @@ impl DigitalInput {
             true as i32 // for input?
         ))?;
 
-        report_usage(resource_types::DigitalInput, channel as instances::Type);
+        usage::report(resource_types::DigitalInput, channel as instances::Type);
 
         Ok(DigitalInput { channel, handle })
     }

--- a/wpilib/src/encoder.rs
+++ b/wpilib/src/encoder.rs
@@ -31,7 +31,6 @@ License version 3 as published by the Free Software Foundation. See
 // TODO: documentation
 
 // TODO: fix variables
-use wpilib_sys::usage::resource_types;
 use wpilib_sys::*;
 
 use crate::dio::DigitalInput;
@@ -89,8 +88,8 @@ impl Encoder {
             encoder: handle,
         };
 
-        report_usage_context(
-            resource_types::Encoder,
+        usage::report_context(
+            usage::resource_types::Encoder,
             encoder.fpga_index()? as u32,
             encoding as HAL_EncoderEncodingType::Type,
         );

--- a/wpilib/src/pdp.rs
+++ b/wpilib/src/pdp.rs
@@ -51,7 +51,7 @@ impl PowerDistributionPanel {
     /// Create a new PDP interface on the specified module.
     pub fn new_with_module(module: i32) -> HalResult<PowerDistributionPanel> {
         let handle = hal_call!(HAL_InitializePDP(module))?;
-        report_usage(resource_types::PDP, module as instances::Type);
+        usage::report(resource_types::PDP, module as instances::Type);
         Ok(PowerDistributionPanel { handle })
     }
 

--- a/wpilib/src/pneumatics.rs
+++ b/wpilib/src/pneumatics.rs
@@ -95,7 +95,7 @@ impl Solenoid {
             channel
         )))?;
 
-        report_usage_context(
+        usage::report_context(
             resource_types::Solenoid,
             channel as instances::Type,
             module_number,

--- a/wpilib/src/pwm.rs
+++ b/wpilib/src/pwm.rs
@@ -38,7 +38,7 @@ impl PWM {
         hal_call!(HAL_SetPWMDisabled(handle))?;
         hal_call!(HAL_SetPWMEliminateDeadband(handle, false as i32))?;
 
-        report_usage(resource_types::PWM, channel as instances::Type);
+        usage::report(resource_types::PWM, channel as instances::Type);
 
         Ok(PWM { channel, handle })
     }
@@ -194,7 +194,7 @@ impl PwmSpeedController {
         pwm.set_period_multiplier(PeriodMultiplier::Multiplier1x)?;
         pwm.set_speed(0.0)?;
         pwm.set_zero_latch()?;
-        report_usage(resource_types::PWMTalonSRX, channel as instances::Type);
+        usage::report(resource_types::PWMTalonSRX, channel as instances::Type);
         Ok(PwmSpeedController {
             pwm,
             inverted: false,

--- a/wpilib/src/robot_base.rs
+++ b/wpilib/src/robot_base.rs
@@ -63,7 +63,7 @@ impl RobotBase {
             return Err(RobotBaseInitError::HalInitFailed);
         }
 
-        report_usage(usage::resource_types::Language, unsafe {
+        usage::report(usage::resource_types::Language, unsafe {
             mem::transmute(*b"Rust")
         });
         println!("\n********** Hardware Init **********\n");

--- a/wpilib/src/serial.rs
+++ b/wpilib/src/serial.rs
@@ -87,7 +87,7 @@ impl SerialPort {
         serial_port.set_write_buf_mode(WriteBufferMode::FlushOnAcces)?;
 
         serial_port.enable_termination(b'\n')?;
-        report_usage(usage::resource_types::SerialPort, 0);
+        usage::report(usage::resource_types::SerialPort, 0);
         Ok(serial_port)
     }
 

--- a/wpilib/src/spi.rs
+++ b/wpilib/src/spi.rs
@@ -30,7 +30,7 @@ impl Spi {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(port: Port) -> HalResult<Self> {
         hal_call!(HAL_InitializeSPI(port as HAL_SPIPort::Type))?;
-        report_usage(usage::resource_types::SPI, 1);
+        usage::report(usage::resource_types::SPI, 1);
         Ok(Spi {
             port: port as HAL_SPIPort::Type,
             msb_first: false,


### PR DESCRIPTION
- Keep usage reporting in a single namespace.
- Rename `report_extras` to `report_feature` and enforce correctness of strings statically (#38).

Probably goes without saying that this is a breaking change.