### PR TITLE
Add IterativeRobot framework

### DIFF
--- a/wpilib-examples/Cargo.toml
+++ b/wpilib-examples/Cargo.toml
@@ -37,3 +37,7 @@ path = "./pdp.rs"
 [[bin]]
 name = "pneumatics"
 path = "./pneumatics.rs"
+
+[[bin]]
+name = "timed_robot"
+path = "./timed_robot.rs"

--- a/wpilib-examples/timed_robot.rs
+++ b/wpilib-examples/timed_robot.rs
@@ -1,0 +1,41 @@
+extern crate wpilib;
+
+#[derive(Debug)]
+struct Robot {}
+
+impl wpilib::IterativeRobot for Robot {
+    fn disabled_init(&mut self) {
+        println!("Transitioning to disabled.");
+    }
+
+    fn autonomous_init(&mut self) {
+        println!("Transitioning to autonomous mode.");
+    }
+
+    fn teleop_init(&mut self) {
+        println!("Transitioning to teleoperated mode.");
+    }
+
+    fn test_init(&mut self) {
+        println!("Transitioning to test mode.");
+    }
+
+    fn disabled_periodic(&mut self) {}
+
+    fn autonomous_periodic(&mut self) {}
+
+    fn teleop_periodic(&mut self) {}
+
+    fn test_periodic(&mut self) {}
+
+    fn robot_periodic(&mut self) {}
+}
+
+fn main() {
+    let base = wpilib::RobotBase::new().unwrap();
+    let ds = base.make_ds();
+
+    let mut robot = Robot {};
+
+    wpilib::start_timed(&mut robot, &ds)
+}

--- a/wpilib/src/lib.rs
+++ b/wpilib/src/lib.rs
@@ -20,6 +20,8 @@ pub mod encoder;
 pub mod notifier;
 pub mod pneumatics;
 pub mod pwm;
+mod robot;
+pub use self::robot::*;
 mod robot_base;
 pub use self::robot_base::*;
 pub mod serial;

--- a/wpilib/src/lib.rs
+++ b/wpilib/src/lib.rs
@@ -17,6 +17,7 @@ pub use self::pdp::PowerDistributionPanel;
 pub mod dio;
 pub mod ds;
 pub mod encoder;
+pub mod notifier;
 pub mod pneumatics;
 pub mod pwm;
 mod robot_base;

--- a/wpilib/src/notifier.rs
+++ b/wpilib/src/notifier.rs
@@ -1,0 +1,73 @@
+// Copyright 2019 First Rust Competition Developers.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// use std::time::Duration;
+use wpilib_sys::*;
+
+#[derive(Debug)]
+/// An FPGA notifier alarm.
+pub struct Alarm {
+    handle: HAL_NotifierHandle,
+}
+
+impl Alarm {
+    pub fn new() -> HalResult<Self> {
+        Ok(Alarm {
+            handle: hal_call!(HAL_InitializeNotifier())?,
+        })
+    }
+
+    pub fn stop(&self) -> HalResult<()> {
+        hal_call!(HAL_StopNotifier(self.handle))
+    }
+
+    /// Updates the trigger time.
+    ///
+    /// Note that this time is an absolute FPGA timestamp.
+    pub fn update(&self, trigger_time: u64) -> HalResult<()> {
+        hal_call!(HAL_UpdateNotifierAlarm(self.handle, trigger_time))
+    }
+
+    pub fn cancel(&self) -> HalResult<()> {
+        hal_call!(HAL_CancelNotifierAlarm(self.handle))
+    }
+
+    /// Waits for the next alarm.
+    ///
+    /// This is a blocking call until either the time elapses or
+    /// the stop method is called.
+    ///
+    /// Returns the FPGA timestamp at which the alarm returned.
+    pub fn wait(&self) -> HalResult<u64> {
+        hal_call!(HAL_WaitForNotifierAlarm(self.handle))
+    }
+}
+
+impl Drop for Alarm {
+    fn drop(&mut self) {
+        let _ = self.stop();
+        let _ = hal_call!(HAL_CleanNotifier(self.handle));
+    }
+}
+
+/*
+pub struct Notifier {
+    thread: std::thread::Thread,
+    alarm: Alarm,
+}
+
+impl Notifier {
+    pub fn new(handler: FnMut(), period: Duration) -> HalResult<Self> {
+        let alarm = Alarm::new(),
+        let thread = std::thread::spawn(|| loop {
+            let cur_time = hal_call!(HAL_WaitForNotifierAlarm(notifier));
+            handler();
+
+        });
+    }
+}
+*/

--- a/wpilib/src/robot.rs
+++ b/wpilib/src/robot.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use std::time;
 use wpilib_sys::{
-    HAL_ObserveUserProgramAutonomous, HAL_ObserveUserProgramDisabled,
+    usage, HAL_ObserveUserProgramAutonomous, HAL_ObserveUserProgramDisabled,
     HAL_ObserveUserProgramStarting, HAL_ObserveUserProgramTeleop, HAL_ObserveUserProgramTest,
 };
 
@@ -92,6 +92,11 @@ fn loop_func<T: IterativeRobot>(
 pub fn start_iterative<T: IterativeRobot>(robot: &mut T, ds: &DriverStation) {
     let mut last_mode: Option<RobotState> = None;
 
+    usage::report(
+        usage::resource_types::Framework,
+        usage::instances::kFramework_Iterative,
+    );
+
     println!("\n********** Robot program starting **********\n");
     unsafe { HAL_ObserveUserProgramStarting() }
 
@@ -123,6 +128,11 @@ pub fn start_timed_with_period<T: IterativeRobot>(
     let mut last_mode: Option<RobotState> = None;
     let notifier = Alarm::new().expect("Failed to initialize FPGA notifier");
     let period = period.as_micros() as u64;
+
+    usage::report(
+        usage::resource_types::Framework,
+        usage::instances::kFramework_Timed,
+    );
 
     println!("\n********** Robot program starting **********\n");
     unsafe { HAL_ObserveUserProgramStarting() }

--- a/wpilib/src/robot.rs
+++ b/wpilib/src/robot.rs
@@ -51,21 +51,13 @@ fn loop_func<T: IterativeRobot>(
     cur_mode: RobotState,
 ) {
     // Check for state transitions
-    match (last_mode, cur_mode) {
-        (Some(RobotState::Disabled), RobotState::Disabled) => (),
-        (_, RobotState::Disabled) => robot.disabled_init(),
-
-        (Some(RobotState::Autonomous), RobotState::Autonomous) => (),
-        (_, RobotState::Autonomous) => robot.autonomous_init(),
-
-        (Some(RobotState::Teleop), RobotState::Teleop) => (),
-        (_, RobotState::Teleop) => robot.teleop_init(),
-
-        (Some(RobotState::Test), RobotState::Test) => (),
-        (_, RobotState::Test) => robot.test_init(),
-
-        // XXX: This really should look the same as disabled
-        (_, RobotState::EStop) => (),
+    if last_mode != Some(cur_mode) {
+        match cur_mode {
+            RobotState::Autonomous => robot.autonomous_init(),
+            RobotState::Teleop => robot.teleop_init(),
+            RobotState::Test => robot.test_init(),
+            _ => robot.disabled_init(),
+        }
     }
 
     // Call the appropriate periodic function

--- a/wpilib/src/robot.rs
+++ b/wpilib/src/robot.rs
@@ -1,0 +1,155 @@
+// Copyright 2019 First Rust Competition Developers.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::{
+    ds::{DriverStation, RobotState},
+    notifier::Alarm,
+    RobotBase,
+};
+use std::time;
+use wpilib_sys::{
+    HAL_ObserveUserProgramAutonomous, HAL_ObserveUserProgramDisabled,
+    HAL_ObserveUserProgramStarting, HAL_ObserveUserProgramTeleop, HAL_ObserveUserProgramTest,
+};
+
+/// Implements a specific type of robot program framework, for
+/// `start_iterative` and `start_timed`.
+///
+/// The init methods are called whenever the appropriate mode is entered.
+///
+/// The periodic functions are called for the appropriate mode on an interval.
+pub trait IterativeRobot {
+    fn disabled_init(&mut self) {
+        println!("Default disabled_init method... Override me!");
+    }
+    fn autonomous_init(&mut self) {
+        println!("Default autonomous_init method... Override me!");
+    }
+    fn teleop_init(&mut self) {
+        println!("Default teleop_init method... Override me!");
+    }
+    fn test_init(&mut self) {
+        println!("Default test_init method... Override me!");
+    }
+
+    /// Periodic code for all modes should go here.
+    fn robot_periodic(&mut self) {}
+
+    fn disabled_periodic(&mut self) {}
+    fn autonomous_periodic(&mut self) {}
+    fn teleop_periodic(&mut self) {}
+    fn test_periodic(&mut self) {}
+}
+
+fn loop_func<T: IterativeRobot>(
+    robot: &mut T,
+    last_mode: Option<RobotState>,
+    cur_mode: RobotState,
+) {
+    // Check for state transitions
+    match (last_mode, cur_mode) {
+        (Some(RobotState::Disabled), RobotState::Disabled) => (),
+        (_, RobotState::Disabled) => robot.disabled_init(),
+
+        (Some(RobotState::Autonomous), RobotState::Autonomous) => (),
+        (_, RobotState::Autonomous) => robot.autonomous_init(),
+
+        (Some(RobotState::Teleop), RobotState::Teleop) => (),
+        (_, RobotState::Teleop) => robot.teleop_init(),
+
+        (Some(RobotState::Test), RobotState::Test) => (),
+        (_, RobotState::Test) => robot.test_init(),
+
+        // XXX: This really should look the same as disabled
+        (_, RobotState::EStop) => (),
+    }
+
+    // Call the appropriate periodic function
+    match cur_mode {
+        RobotState::Autonomous => {
+            unsafe { HAL_ObserveUserProgramAutonomous() }
+            robot.autonomous_periodic()
+        }
+        RobotState::Teleop => {
+            unsafe { HAL_ObserveUserProgramTeleop() }
+            robot.teleop_periodic()
+        }
+        RobotState::Test => {
+            unsafe { HAL_ObserveUserProgramTest() }
+            robot.test_periodic()
+        }
+        _ => {
+            unsafe { HAL_ObserveUserProgramDisabled() }
+            robot.disabled_periodic()
+        }
+    }
+
+    robot.robot_periodic()
+}
+
+/// Start the main robot loop for an IterativeRobot.
+/// The periodic methods are called each time a new packet
+/// received from the driver station.
+///
+/// It is recommended to use `start_timed` instead,
+/// which guarantees a more regular period of execution.
+pub fn start_iterative<T: IterativeRobot>(robot: &mut T, ds: &DriverStation) {
+    let mut last_mode: Option<RobotState> = None;
+
+    println!("\n********** Robot program starting **********\n");
+    unsafe { HAL_ObserveUserProgramStarting() }
+
+    loop {
+        ds.wait_for_data();
+
+        let cur_mode = ds.robot_state();
+        loop_func(robot, last_mode, cur_mode);
+        last_mode = Some(cur_mode);
+    }
+}
+
+/// Start the main robot loop for an IterativeRobot.
+/// The periodic methods are called every 20 milliseconds.
+///
+/// If you wish to have your main loop run at a different rate,
+/// use `start_timed_with_period`.
+pub fn start_timed<T: IterativeRobot>(robot: &mut T, ds: &DriverStation) {
+    start_timed_with_period(robot, ds, time::Duration::from_millis(20))
+}
+
+/// Start the main robot loop for an IterativeRobot.
+/// The periodic methods are called on a regular interval specified by `period`.
+pub fn start_timed_with_period<T: IterativeRobot>(
+    robot: &mut T,
+    ds: &DriverStation,
+    period: time::Duration,
+) {
+    let mut last_mode: Option<RobotState> = None;
+    let notifier = Alarm::new().expect("Failed to initialize FPGA notifier");
+    let period = period.as_micros() as u64;
+
+    println!("\n********** Robot program starting **********\n");
+    unsafe { HAL_ObserveUserProgramStarting() }
+
+    let mut expiration_time =
+        RobotBase::fpga_time().expect("Failed to read current FPGA time") + period;
+    let _ = notifier.update(expiration_time);
+
+    loop {
+        let cur_time = notifier.wait().unwrap();
+        if cur_time == 0 {
+            break;
+        }
+
+        expiration_time += period;
+        let _ = notifier.update(expiration_time);
+
+        let cur_mode = ds.robot_state();
+        loop_func(robot, last_mode, cur_mode);
+        last_mode = Some(cur_mode);
+    }
+}


### PR DESCRIPTION
This adds a notifier alarm (basically a condition variable on an FPGA interrupt) wrapper, an IterativeRobot trait (with the familiar init and periodic methods), and a number of main loop implementations:

- `start_iterative` waits for DS control packets before each iteration.
- `start_timed` runs every 20ms off a notifier.
- `start_timed_with_period` runs at a regular period (specified by the user) with a notifier.