### PR TITLE
Make SPI safe

### DIFF
--- a/wpilib/src/spi.rs
+++ b/wpilib/src/spi.rs
@@ -44,10 +44,8 @@ impl Spi {
         })
     }
 
-    pub fn set_clock_rate(&mut self, hz: f64) {
-        unsafe {
-            HAL_SetSPISpeed(self.port, hz as i32); // all of my what but its honestly what they do
-        }
+    pub fn set_clock_rate(&mut self, hz: i32) {
+        unsafe { HAL_SetSPISpeed(self.port, hz as i32) }
     }
 
     #[inline]

--- a/wpilib/src/spi.rs
+++ b/wpilib/src/spi.rs
@@ -35,7 +35,7 @@ impl Spi {
     pub fn new(port: Port) -> HalResult<Self> {
         let port = port as HAL_SPIPort::Type;
         hal_call!(HAL_InitializeSPI(port))?;
-        usage::report(usage::resource_types::SPI, 1);
+        usage::report(usage::resource_types::SPI, port as _);
         Ok(Spi {
             port,
             msb_first: false,


### PR DESCRIPTION
Also expose underlying I/O errors instead of returning -1.